### PR TITLE
Fix CI functional test permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,8 @@ jobs:
           cp .env.example .env || touch .env
           echo "HOST_UID=$(id -u)" >> .env
           echo "HOST_GID=$(id -g)" >> .env
+          mkdir -p logs
+          chmod -R 777 logs
 
       - name: Run general functional tests (no external API costs)
         run: |


### PR DESCRIPTION
Added mkdir and chmod for logs directory in CI workflow to resolve permission denied errors in functional tests. This should fix the failing tests on CI while keeping them passing locally.